### PR TITLE
Some improvements

### DIFF
--- a/src/Structr/Structr.php
+++ b/src/Structr/Structr.php
@@ -38,9 +38,11 @@ class Structr
         self::$_definitions = array();
     }
 
-    public static function define($name) {
+    public static function define($name = null) {
         $node = new DefinitionNode();
-        self::$_definitions[$name] = $node;
+        if (!empty($name)) {
+            self::$_definitions[$name] = $node;
+        }
 
         return $node;
     }

--- a/src/Structr/Tree/Base/Node.php
+++ b/src/Structr/Tree/Base/Node.php
@@ -75,12 +75,14 @@ abstract class Node
         return $this->parent();
     }
 
-    public function run() {
+    public function run($value = null) {
         if ($this->_parent !== null) {
-            return $this->root()->run();
+            return $this->root()->run($value);
         }
 
-        $value = $this->getValue();
+        if ($value === null) {
+            $value = $this->getValue();
+        }
 
         $return = $this->_walk_value($value);
 

--- a/src/Structr/Tree/Base/NumberNode.php
+++ b/src/Structr/Tree/Base/NumberNode.php
@@ -84,4 +84,10 @@ abstract class NumberNode extends ScalarNode
 
         return $value;
     }
+
+    public function setType(&$value) {
+        if ($this->_coerceStrict && !is_numeric($value))
+            return false;
+        return parent::setType($value);
+    }
 }

--- a/src/Structr/Tree/Base/ScalarNode.php
+++ b/src/Structr/Tree/Base/ScalarNode.php
@@ -23,7 +23,8 @@ abstract class ScalarNode extends Node
                                                       $this->_coerceStrict);
         }
 
-        if ($this->_coerceStrict || !@settype($value, $this->getScalarType()))
+        $typeok = $this->setType($value, $this->getScalarType());
+        if ($this->_coerceStrict && !$typeok)
             throw new Exception("Can't coerce '$type' to '"
                                 . $this->getScalarType() ."'");
 
@@ -39,6 +40,11 @@ abstract class ScalarNode extends Node
         return $this;
     }
 
+    public function setType(&$value)
+    {
+        return @settype($value, $this->getScalarType());
+    }
+
     protected function _walk_value($value) {
         $value = parent::_walk_value($value);
 
@@ -48,6 +54,6 @@ abstract class ScalarNode extends Node
         }
 
         throw new Exception("Invalid type for '" . gettype($value)
-                            . "', expecting " . $this->getScalarType());
+                            . "', expecting '" . $this->getScalarType() . "'");
     }
 }

--- a/src/Structr/Tree/Base/ScalarNode.php
+++ b/src/Structr/Tree/Base/ScalarNode.php
@@ -33,6 +33,10 @@ abstract class ScalarNode extends Node
 
     public abstract function getScalarType();
 
+    public function strict() {
+        return $this->coerce(true);
+    }
+
     public function coerce($strict = false) {
         $this->_coerce = true;
         $this->_coerceStrict = $strict;

--- a/src/Structr/Tree/Scalar/IntegerNode.php
+++ b/src/Structr/Tree/Scalar/IntegerNode.php
@@ -11,4 +11,9 @@ class IntegerNode extends NumberNode
         return "integer";
     }
 
+    public function setType(&$value) {
+        if ($this->_coerceStrict && is_string($value) && !ctype_digit($value))
+            return false;
+        return parent::setType($value);
+    }
 }

--- a/tests/Structr/Test/CoercionTest.php
+++ b/tests/Structr/Test/CoercionTest.php
@@ -67,6 +67,19 @@ class CoercionTest extends \PHPUnit_Framework_TestCase
                                    ->run());
     }
 
+    public function testIntegerStrict() {
+        $this->assertSame(123, Structr::ize("123")
+                                   ->isInteger()->coerce(true)
+                                   ->run());
+        $this->assertSame(0, Structr::ize("0")
+                                   ->isInteger()->coerce(true)
+                                   ->run());
+
+        $this->setExpectedException('\Structr\Exception');
+        Structr::ize('invalidnumber')->isInteger()->coerce(true)->run();
+    }
+
+
     public function testFloat() {
         $this->assertEquals(0, Structr::ize(null)
                                      ->isFloat()->coerce()

--- a/tests/Structr/Test/DefinitionTest.php
+++ b/tests/Structr/Test/DefinitionTest.php
@@ -57,4 +57,21 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $result);
     }
+
+    public function testEmptyDefinition() {
+        Structr::clearAll();
+
+        $structr = Structr::define()->isInteger()->end();
+        $this->assertInstanceOf('Structr\Tree\DefinitionNode', $structr);
+    }
+
+
+    public function testRunWithValue() {
+        Structr::clearAll();
+        $structr = Structr::define()->isInteger()->end();
+
+        $expected = 2;
+        $this->assertSame($expected, $structr->run(2));
+    }
+
 }


### PR DESCRIPTION
- Allow define() without arguments to create an unregistered DefinitionNode
- Allow run() to take a $value argument to separate definition from value processing.
- Fixed strict coercion and improved strict coercion test for numbers ... 
- Added strict() shortcut to scalar values: 
  `->isInteger()->strict() == ->isInteger->coerce(true)`
