### PR TITLE
Added DeferredNode, fixed PrototypeNode::is()

### DIFF
--- a/src/Structr/Tree/Base/PrototypeNode.php
+++ b/src/Structr/Tree/Base/PrototypeNode.php
@@ -201,7 +201,7 @@ abstract class PrototypeNode extends Node
      */
     public function is($definition)
     {
-        if (is_object($definition) && $definition instanceof RootNode) {
+        if (is_object($definition) && $definition instanceof Node) {
             $this->_prototype = $definition;
         } else {
             $this->_prototype = clone Structr::getDefinition($definition);

--- a/src/Structr/Tree/Base/PrototypeNode.php
+++ b/src/Structr/Tree/Base/PrototypeNode.php
@@ -203,7 +203,7 @@ abstract class PrototypeNode extends Node
     public function is($definition)
     {
         if (is_object($definition) && $definition instanceof Node) {
-            $this->_prototype = $definition;
+            $this->_prototype = $definition->root();
         } else if (is_callable($definition)) {
             $this->_prototype = new DeferredNode($definition);
         } else {

--- a/src/Structr/Tree/Base/PrototypeNode.php
+++ b/src/Structr/Tree/Base/PrototypeNode.php
@@ -10,6 +10,7 @@ namespace Structr\Tree\Base;
 
 use Structr\Structr;
 use Structr\Tree\RootNode;
+use Structr\Tree\DeferredNode;
 
 use Structr\Tree\Scalar\IntegerNode;
 use Structr\Tree\Scalar\FloatNode;
@@ -203,6 +204,8 @@ abstract class PrototypeNode extends Node
     {
         if (is_object($definition) && $definition instanceof Node) {
             $this->_prototype = $definition;
+        } else if (is_callable($definition)) {
+            $this->_prototype = new DeferredNode($definition);
         } else {
             $this->_prototype = clone Structr::getDefinition($definition);
         }

--- a/src/Structr/Tree/DeferredNode.php
+++ b/src/Structr/Tree/DeferredNode.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Structr\Tree;
+
+use Structr\Exception;
+use Structr\Tree\Base\Node;
+
+/**
+ * Node that stores a callable that will be
+ * executed when the node is evaluated (Just In Time)
+ */
+class DeferredNode extends Node
+{
+    private $_callable;
+
+    /**
+     * Create a new node
+     *
+     * @param Callable $callable A callable that
+     *        returns an instance of \Structr\Tree\Base\Node or \Structr\Tree\RootNode
+     */
+    public function __construct($callable)
+    {
+        if (!is_callable($callable))
+        {
+            throw new Exception('Argument to DeferredNode::__construct() must be callable');
+        }
+        $this->_callable = $callable;
+    }
+
+    public function _walk_value($value)
+    {
+        $value = parent::_walk_value($value);
+        $node = call_user_func($this->_callable);
+        if (!($node instanceof Node))
+        {
+            throw new Exception(
+                'Callable supplied to is() must return an instance of \Structr\Tree\Base\Node'
+            );
+        }
+        return $node->root()->_walk_value($value);
+    }
+}

--- a/tests/Structr/Test/DeferredTest.php
+++ b/tests/Structr/Test/DeferredTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright (c) 2012 Gijs Kunze
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Structr\Test;
+
+use Structr\Structr;
+
+class DeferredTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDeferredSuccess() {
+        Structr::clearAll();
+        $structr = Structr::ize('foo')->is(function() {
+            return Structr::define()->isString()->enum(array('foo', 'baz', 'bar'))->coerce();
+        });
+
+        $this->assertSame('foo', $structr->run());
+    }
+
+    public function testDeferredFail() {
+        Structr::clearAll();
+        $structr = Structr::ize('ban')->is(function() {
+            return Structr::define()->isString()->enum(array('foo', 'baz', 'bar'))->coerce();
+        });
+
+        $this->setExpectedException('Structr\Exception', "'ban' not part of enum");
+        $structr->run();
+    }
+
+    public function testDeferredInvalidReturnType() {
+        Structr::clearAll();
+        $structr = Structr::ize(4)->is(function() { return new \stdClass(); });
+
+        $this->setExpectedException(
+            'Structr\Exception',
+            'Callable supplied to is() must return an instance of \Structr\Tree\Base\Node'
+        );
+        $structr->run();
+    }
+}

--- a/tests/Structr/Test/DefinitionTest.php
+++ b/tests/Structr/Test/DefinitionTest.php
@@ -80,4 +80,15 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $structr->run(2));
     }
 
+    public function testWithDefinition()
+    {
+        Structr::clearAll();
+        $structr = Structr::define()->is(
+            Structr::define()->isInteger()->coerce()
+        );
+
+        $this->assertSame(4, $structr->run(4));
+
+    }
+
 }


### PR DESCRIPTION
Added a DeferredNode, which can be created via PrototypeNode::is() by passing it a `callable`. A DeferredNode does not have a definition that can be walked, but when it is called (i.e., DeferredNode::_walk_value), it will call the `callable`, and run the value through the result of that `callable`.
This can be interesting in instances where you want to predefine a certain type (say, currency) for use throughout an API and you want to fetch the currencies from a database first to built an enum, but you don't want to do this if the definition isn't used at all since that causes a round trip to the database for nothing.

Example

``` php
$struct = Structr::define('currency')->currency()->is(function() use ($db) {
    // assume $db instanceof \PDO
    $stmt = $db->query('SELECT id FROM currency');
    $currencies = array_column($stmt->fetchAll(\PDO::FETCH_ASSOC), 'id');
    return Structr::define()->isString()->enum($currencies)->end();
});

// query isn't run yet

Strucrt::ize($something)->is('currency'); // query will run here
```

(array_column from this example is PHP >= 5.5: http://be2.php.net/manual/en/function.array-column.php)
