### PR TITLE
Adding Descriptions to Nodes for Documentation Purposes

### DIFF
--- a/src/Structr/Tree/Base/Node.php
+++ b/src/Structr/Tree/Base/Node.php
@@ -38,6 +38,11 @@ abstract class Node
     private $_id = null;
 
     /**
+     * @var string A description of the key/value
+     */
+    private $_description;
+
+    /**
      * IDs that are currently registered on this node
      */
     private $_registeredIds = array();
@@ -88,6 +93,29 @@ abstract class Node
     public function setId($id) {
         $this->registerId($id, $this);
         $this->_id = $id;
+    }
+
+    /**
+     * Set the description of the key/value
+     *
+     * @param string $description
+     */
+    public function description($description)
+    {
+        if(!is_string($description)) {
+            throw new Exception("\$description must be a string");
+        }
+        $this->_description = $description;
+    }
+
+    /**
+     * Get the description of the key/value
+     *
+     * @return string The description
+     */
+    public function getDescription()
+    {
+        return $this->_description()
     }
 
     /**

--- a/src/Structr/Tree/Base/Node.php
+++ b/src/Structr/Tree/Base/Node.php
@@ -115,7 +115,7 @@ abstract class Node
      */
     public function getDescription()
     {
-        return $this->_description()
+        return $this->_description();
     }
 
     /**

--- a/src/Structr/Tree/Composite/MapKeyNode.php
+++ b/src/Structr/Tree/Composite/MapKeyNode.php
@@ -35,11 +35,6 @@ class MapKeyNode extends PrototypeNode
     private $_name;
 
     /**
-     * @var string A description of the key/value
-     */
-    private $_description;
-
-    /**
      * Set the name of this key
      * 
      * @param string $name The name
@@ -57,29 +52,6 @@ class MapKeyNode extends PrototypeNode
     public function getName()
     {
         return $this->_name;
-    }
-
-    /**
-     * Set the description of the key/value
-     *
-     * @param string $description
-     */
-    public function description($description)
-    {
-        if(!is_string($description)) {
-            throw new \Exception("\$description must be a string");
-        }
-        $this->_description = $description;
-    }
-
-    /**
-     * Get the description of the key/value
-     *
-     * @return string The description
-     */
-    public function getDescription()
-    {
-        return $this->_description()
     }
 
     /**

--- a/src/Structr/Tree/Composite/MapKeyNode.php
+++ b/src/Structr/Tree/Composite/MapKeyNode.php
@@ -35,6 +35,11 @@ class MapKeyNode extends PrototypeNode
     private $_name;
 
     /**
+     * @var string A description of the key/value
+     */
+    private $_description;
+
+    /**
      * Set the name of this key
      * 
      * @param string $name The name
@@ -52,6 +57,29 @@ class MapKeyNode extends PrototypeNode
     public function getName()
     {
         return $this->_name;
+    }
+
+    /**
+     * Set the description of the key/value
+     *
+     * @param string $description
+     */
+    public function description($description)
+    {
+        if(!is_string($description)) {
+            throw new \Exception("\$description must be a string");
+        }
+        $this->_description = $description;
+    }
+
+    /**
+     * Get the description of the key/value
+     *
+     * @return string The description
+     */
+    public function getDescription()
+    {
+        return $this->_description()
     }
 
     /**

--- a/tests/Structr/Test/Composite/JsonTest.php
+++ b/tests/Structr/Test/Composite/JsonTest.php
@@ -136,7 +136,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
         $input = '{"a":1}}';
         
         $this->setExpectedException(
-            '\Structr\Exception', 'Invalid or malformed JSON'
+            '\Structr\Exception', 'Syntax error'
         );
                 
         Structr::ize($input)


### PR DESCRIPTION
My team and I are using a deep analysis of our Structr definitions to automatically generate documentation for our API.

I've been wanting to add a "description" property to the Structr nodes for a while, so that we can provide some semantic documentation as well, in a similar way.

This is also handy because we can use it to provide more meaningful error messages if a value in the client's payload isn't right for some reason.